### PR TITLE
Adds export to PNG and export to JPEG

### DIFF
--- a/lib/svg-to-raster.coffee
+++ b/lib/svg-to-raster.coffee
@@ -1,0 +1,23 @@
+exports.transform = (svg, outputType, callback) ->
+  # create an (undisplayed) image
+  img = document.createElement 'img'
+
+  img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent svg
+
+  img.addEventListener 'load', (event) ->
+    # create an (undisplayed) canvas
+    canvas = document.createElement 'canvas'
+    img    = event.target
+
+    # resize the canvas to the size of the image
+    canvas.width  = img.width
+    canvas.height = img.height
+
+    # ... and draw the image on there
+    canvas.getContext('2d').drawImage img, 0, 0
+
+    # smurf the data url of the canvas
+    dataURL = canvas.toDataURL "image/#{outputType}", 0.8
+
+    # extract the base64 encoded image, decode and return it
+    callback(new Buffer(dataURL.replace("data:image/#{outputType};base64,", ''), 'base64'))

--- a/menus/svg-preview.cson
+++ b/menus/svg-preview.cson
@@ -9,3 +9,8 @@
     ]
   }
 ]
+'context-menu':
+  '.svg-preview': [
+    {label: 'Export to PNG\u2026', command: 'svg-preview:export-to-png'},
+    {label: 'Export to JPEG\u2026', command: 'svg-preview:export-to-jpeg'}
+  ]

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "atom": ">0.200.0"
   },
   "dependencies": {
+    "fs-plus": "^2.8.1",
     "atom-space-pen-views": "^2.2.0",
     "debounce": "^1.0.0"
   },
   "devDependencies": {
-    "fs-plus": "^2.8.1",
     "temp": "^0.8.3",
     "wrench": "^1.5.9"
   }

--- a/spec/svg-preview-spec.coffee
+++ b/spec/svg-preview-spec.coffee
@@ -216,3 +216,55 @@ describe "SVG preview package", ->
 
       runs ->
         expect(atom.workspace.getActiveTextEditor()).toBeTruthy()
+
+  describe "when svg-preview:export-to-png is triggered", ->
+    beforeEach ->
+      fixturesPath = path.join(__dirname, 'fixtures')
+      tempPath = temp.mkdirSync('atom')
+      wrench.copyDirSyncRecursive(fixturesPath, tempPath, forceDelete: true)
+      atom.project.setPaths([tempPath])
+
+      workspaceElement = atom.views.getView(atom.workspace)
+      jasmine.attachToDOM(workspaceElement)
+
+    it "saves a PNG and opens it", ->
+      outputPath = temp.path() + 'subdir/file with space.png'
+      previewPaneItem = null
+
+      waitsForPromise ->
+        atom.workspace.open('subdir/file with space.svg')
+      runs ->
+        atom.commands.dispatch workspaceElement, 'svg-preview:toggle'
+      waitsFor ->
+        previewPaneItem = atom.workspace.getPanes()[1].getActiveItem()
+      runs ->
+        spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
+        atom.commands.dispatch previewPaneItem.element, 'svg-preview:export-to-png'
+      waitsFor ->
+        fs.existsSync(outputPath)
+
+      runs ->
+        expect(fs.isFileSync(outputPath)).toBe true
+        writtenFile = fs.readFileSync outputPath
+        expect(writtenFile).toContain "PNG"
+
+    it "saves a JPEG and opens it", ->
+      outputPath = temp.path() + 'subdir/file with space.jpeg'
+      previewPaneItem = null
+
+      waitsForPromise ->
+        atom.workspace.open('subdir/file with space.svg')
+      runs ->
+        atom.commands.dispatch workspaceElement, 'svg-preview:toggle'
+      waitsFor ->
+        previewPaneItem = atom.workspace.getPanes()[1].getActiveItem()
+      runs ->
+        spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
+        atom.commands.dispatch previewPaneItem.element, 'svg-preview:export-to-jpeg'
+      waitsFor ->
+        fs.existsSync(outputPath)
+
+      runs ->
+        expect(fs.isFileSync(outputPath)).toBe true
+        writtenFile = fs.readFileSync outputPath
+        expect(writtenFile).toContain "JFIF"


### PR DESCRIPTION
This adds two commands to svg-preview: `svg-preview:export-to-png` and
`svg-preview:export-to-jpeg`. When triggered, they execute the following
actions (added to `lib/svg-preview-view.coffee` in the `exportTo`
function):
- Convert the current svg to the specified raster format (respectively
  png or jpeg).
    - The canvas API toDataURL function takes care of the conversion.
      Implementation details in `lib/svg-to-raster.coffee`.
- Open a Save As dialog and (after the user closes the Save As dialog)
  saves the raster graphic to the specified location
- Opens the raster graphic

As a first proposal this change binds the commands to context menu
items in the previewer (`menus/svg-preview.cson`)

Notes:
- It uses fs-plus for saving the raster graphics. fs-plus already was a
  development dependency - this change promotes it to a regular
  dependency.
- Both fs-plus and svg-to-raster are only loaded when the conversion
  actions are triggered for the first time, in order for them not to
  impact package load time.
- Specs/ tests for both commands in spec/svg-preview-spec.coffee

![export-to-png](https://cloud.githubusercontent.com/assets/4822597/17195212/dca5b4f8-545c-11e6-9e0f-4492f2fcd56f.gif)
