### PR TITLE
Adds export to PNG and export to JPEG

### DIFF
--- a/lib/svg-preview-view.js
+++ b/lib/svg-preview-view.js
@@ -4,6 +4,8 @@ import path from 'path'
 import { Emitter, Disposable, CompositeDisposable, File } from 'atom'
 import { $, $$$, View } from 'atom-space-pen-views'
 import debounce from 'debounce'
+let fs = null // Defer until used
+let svgToRaster = null // Defer until used
 
 class SvgPreviewView extends View {
 
@@ -173,7 +175,15 @@ class SvgPreviewView extends View {
       'core:move-down': () => this.scrollDown(),
       'svg-preview:zoom-in': () => this.zoom(0.1),
       'svg-preview:zoom-out': () => this.zoom(-0.1),
-      'svg-preview:reset-zoom': () => this.zoomReset()
+      'svg-preview:reset-zoom': () => this.zoomReset(),
+      'svg-preview:export-to-png': (event) => {
+        event.stopPropagation()
+        this.exportTo('png')
+      },
+      'svg-preview:export-to-jpeg': (event) => {
+        event.stopPropagation()
+        this.exportTo('jpeg')
+      },
     })
 
     if (this.file) {
@@ -289,6 +299,45 @@ class SvgPreviewView extends View {
 
   changeBackground(color) {
     this.attr('background', color)
+  }
+
+  exportTo(outputType) {
+    let filePath, outputFilePath, projectPath
+    if (this.loading) {
+      return
+    }
+
+    filePath = this.getPath()
+
+    if (filePath) {
+      filePath = path.join(
+        path.dirname(filePath),
+        path.basename(
+          filePath,
+          path.extname(filePath)
+        )
+      ).concat(`.${outputType}`)
+    } else {
+      filePath = `untitled.${outputType}`
+      if (projectPath = atom.project.getPaths()[0]) {
+        filePath = path.join(projectPath, filePath)
+      }
+    }
+
+    if (outputFilePath = atom.showSaveDialogSync(filePath)) {
+      if (svgToRaster == null) {
+        svgToRaster = require('./svg-to-raster')
+      }
+      if (fs == null) {
+        fs = require('fs-plus')
+      }
+      this.getSvgSource().then((source) => {
+        svgToRaster.transform(source, outputType, (result) => {
+          fs.writeFileSync(outputFilePath, result)
+          atom.workspace.open(outputFilePath)
+        })
+      })
+    }
   }
 }
 

--- a/lib/svg-to-raster.js
+++ b/lib/svg-to-raster.js
@@ -1,0 +1,25 @@
+'use babel'
+
+exports.transform = (svg, outputType, callback) => {
+    let img = document.createElement('img')
+    img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+
+    img.addEventListener('load', (event) => {
+        // create an (undisplayed) canvas
+        let canvas = document.createElement('canvas')
+        let img = event.target
+
+        // resize the canvas to the size of the image
+        canvas.width = img.width
+        canvas.height = img.height
+
+        // ... and draw the image on there
+        canvas.getContext('2d').drawImage(img, 0, 0)
+
+        // smurf the data url of the canvas
+        dataURL = canvas.toDataURL(`image/${outputType}`, 0.8)
+
+        // extract the base64 encoded image, decode and return it
+        return callback(new Buffer(dataURL.replace(`data:image/${outputType};base64,`, ''), 'base64'))
+    })
+}

--- a/menus/svg-preview.cson
+++ b/menus/svg-preview.cson
@@ -9,3 +9,8 @@
     ]
   }
 ]
+'context-menu':
+  '.svg-preview': [
+    {label: 'Export to PNG\u2026', command: 'svg-preview:export-to-png'},
+    {label: 'Export to JPEG\u2026', command: 'svg-preview:export-to-jpeg'}
+  ]

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "test": "apm test"
   },
   "dependencies": {
+    "fs-plus": "^2.9.1",
     "atom-space-pen-views": "^2.2.0",
     "debounce": "^1.0.0"
   },
   "devDependencies": {
-    "fs-plus": "^2.9.1",
     "temp": "^0.8.3",
     "wrench": "^1.5.9"
   }

--- a/spec/svg-preview-spec.js
+++ b/spec/svg-preview-spec.js
@@ -252,44 +252,50 @@ describe('SVG preview package', () => {
       })
       atom.project.setPaths([tempPath])
       workspaceElement = atom.views.getView(atom.workspace)
-      return jasmine.attachToDOM(workspaceElement)
+      jasmine.attachToDOM(workspaceElement)
     })
+
     it("saves a PNG and opens it", () => {
-      let outputPath, previewPaneItem
-      outputPath = `${temp.path()}subdir/file with space.png`
-      previewPaneItem = null
+      let outputPath = `${temp.path()}subdir/file with space.png`
+      let previewPaneItem = null
+
       waitsForPromise(() => atom.workspace.open('subdir/file with space.svg'))
       runs(() => atom.commands.dispatch(workspaceElement, 'svg-preview:toggle'))
+
       waitsFor(() => previewPaneItem = atom.workspace.getPanes()[1].getActiveItem())
       runs(() => {
         spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
-        return atom.commands.dispatch(previewPaneItem.element, 'svg-preview:export-to-png')
+        atom.commands.dispatch(previewPaneItem.element, 'svg-preview:export-to-png')
       })
+
       waitsFor(() => fs.existsSync(outputPath))
-      return runs(() => {
-        let writtenFile
+      runs(() => {
         expect(fs.isFileSync(outputPath)).toBe(true)
-        writtenFile = fs.readFileSync(outputPath)
-        return expect(writtenFile).toContain("PNG")
+
+        let writtenFile = fs.readFileSync(outputPath)
+        expect(writtenFile).toContain("PNG")
       })
     })
-    return it("saves a JPEG and opens it", () => {
-      let outputPath, previewPaneItem
-      outputPath = `${temp.path()}subdir/file with space.jpeg`
-      previewPaneItem = null
+
+    it("saves a JPEG and opens it", () => {
+      let outputPath = `${temp.path()}subdir/file with space.jpeg`
+      let previewPaneItem = null
+
       waitsForPromise(() => atom.workspace.open('subdir/file with space.svg'))
       runs(() => atom.commands.dispatch(workspaceElement, 'svg-preview:toggle'))
+
       waitsFor(() => previewPaneItem = atom.workspace.getPanes()[1].getActiveItem())
       runs(() => {
         spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
-        return atom.commands.dispatch(previewPaneItem.element, 'svg-preview:export-to-jpeg')
+        atom.commands.dispatch(previewPaneItem.element, 'svg-preview:export-to-jpeg')
       })
+
       waitsFor(() => fs.existsSync(outputPath))
-      return runs(() => {
+      runs(() => {
         let writtenFile
         expect(fs.isFileSync(outputPath)).toBe(true)
         writtenFile = fs.readFileSync(outputPath)
-        return expect(writtenFile).toContain("JFIF")
+        expect(writtenFile).toContain("JFIF")
       })
     })
   })

--- a/spec/svg-preview-spec.js
+++ b/spec/svg-preview-spec.js
@@ -241,4 +241,58 @@ describe('SVG preview package', () => {
       runs(() => expect(atom.workspace.getActiveTextEditor()).toBeTruthy())
     })
   })
+
+  describe("when svg-preview:export-to-png is triggered", () => {
+    beforeEach(() => {
+      let fixturesPath, tempPath, workspaceElement
+      fixturesPath = path.join(__dirname, 'fixtures')
+      tempPath = temp.mkdirSync('atom')
+      wrench.copyDirSyncRecursive(fixturesPath, tempPath, {
+        forceDelete: true
+      })
+      atom.project.setPaths([tempPath])
+      workspaceElement = atom.views.getView(atom.workspace)
+      return jasmine.attachToDOM(workspaceElement)
+    })
+    it("saves a PNG and opens it", () => {
+      let outputPath, previewPaneItem
+      outputPath = `${temp.path()}subdir/file with space.png`
+      previewPaneItem = null
+      waitsForPromise(() => atom.workspace.open('subdir/file with space.svg'))
+      runs(() => atom.commands.dispatch(workspaceElement, 'svg-preview:toggle'))
+      waitsFor(() => previewPaneItem = atom.workspace.getPanes()[1].getActiveItem())
+      runs(() => {
+        spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
+        return atom.commands.dispatch(previewPaneItem.element, 'svg-preview:export-to-png')
+      })
+      waitsFor(() => fs.existsSync(outputPath))
+      return runs(() => {
+        let writtenFile
+        expect(fs.isFileSync(outputPath)).toBe(true)
+        writtenFile = fs.readFileSync(outputPath)
+        return expect(writtenFile).toContain("PNG")
+      })
+    })
+    return it("saves a JPEG and opens it", () => {
+      let outputPath, previewPaneItem
+      outputPath = `${temp.path()}subdir/file with space.jpeg`
+      previewPaneItem = null
+      waitsForPromise(() => atom.workspace.open('subdir/file with space.svg'))
+      runs(() => atom.commands.dispatch(workspaceElement, 'svg-preview:toggle'))
+      waitsFor(() => previewPaneItem = atom.workspace.getPanes()[1].getActiveItem())
+      runs(() => {
+        spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
+        return atom.commands.dispatch(previewPaneItem.element, 'svg-preview:export-to-jpeg')
+      })
+      waitsFor(() => fs.existsSync(outputPath))
+      return runs(() => {
+        let writtenFile
+        expect(fs.isFileSync(outputPath)).toBe(true)
+        writtenFile = fs.readFileSync(outputPath)
+        return expect(writtenFile).toContain("JFIF")
+      })
+    })
+  })
+
+
 })


### PR DESCRIPTION
(= #33, decaffeinated to es6)

This adds two commands to svg-preview: `svg-preview:export-to-png`
and`svg-preview:export-to-jpeg`. When triggered, they execute the following
actions (added to `lib/svg-preview-view.js` in the `exportTo`
function):
- Convert the current svg to the specified raster format
  (respectively
  png or jpeg).
    - The canvas API toDataURL function takes care of the
      conversion.
      Implementation details in `lib/svg-to-raster.js`.
- Open a Save As dialog and (after the user closes the Save As
  dialog)
  saves the raster graphic to the specified location
- Opens the raster graphic

As a first proposal this change binds the commands to context menu
items in the previewer (`menus/svg-preview.cson`)

Notes:
- It uses fs-plus for saving the raster graphics. fs-plus already
  was a development dependency - this change promotes it to a regular
  one.
- Both fs-plus and svg-to-raster are only loaded when the conversion
  actions are triggered for the first time, in order for them not to
  impact package load time.
- Specs/ tests for both commands in `spec/svg-preview-spec.js`

![export-to-png](https://cloud.githubusercontent.com/assets/4822597/17229436/c86140fa-5517-11e6-8fe1-e1fe45a30e1a.gif)