### PR TITLE
expose zoom commands as buttons

### DIFF
--- a/lib/svg-preview-view.js
+++ b/lib/svg-preview-view.js
@@ -161,6 +161,10 @@ class SvgPreviewView extends View {
   }
 
   zoomTo(zoomValue) {
+    if (zoomValue <= Number.EPSILON) {
+      return
+    }
+
     this.resetZoomButton.text(`${Math.round(zoomValue * 100)}%`)
 
     this.zoomValue = zoomValue

--- a/lib/svg-preview-view.js
+++ b/lib/svg-preview-view.js
@@ -27,6 +27,17 @@ class SvgPreviewView extends View {
             this.text('transparent')
           })
         })
+        this.div({ class: 'image-controls-group btn-group' }, () => {
+          this.button({ class: 'btn', outlet: 'zoomOutButton' }, () => {
+            this.text('-')
+          })
+          this.button({ class: 'btn reset-zoom-button', outlet: 'resetZoomButton' }, () => {
+            this.text('100%')
+          })
+          this.button({ class: 'btn', outlet: 'zoomInButton' }, () => {
+            this.text('+')
+          })
+        })
       })
       this.div({ outlet: 'canvas', class: 'image-canvas' })
     })
@@ -69,6 +80,9 @@ class SvgPreviewView extends View {
       console.log($(e.target).attr('value'))
       this.changeBackground($(e.target).attr('value'))
     })
+    this.zoomOutButton.on('click', (e) => this.zoom(-0.1))
+    this.resetZoomButton.on('click', (e) => this.zoomReset())
+    this.zoomInButton.on('click', (e) => this.zoom(0.1))
   }
 
   serialize() {
@@ -147,6 +161,8 @@ class SvgPreviewView extends View {
   }
 
   zoomTo(zoomValue) {
+    this.resetZoomButton.text(`${Math.round(zoomValue * 100)}%`)
+
     this.zoomValue = zoomValue
 
     const svg = this.canvas.find('svg')


### PR DESCRIPTION
This patch exposes the zoom commands as easier accessible buttons in the preview view.

I didn't use icons for now since I wasn't sure if the additional dependency is desired. But icons instead of the text would probably make the buttons looks nicer and a bit more intuitive.

Any feedback is highly appreciated.