### PR TITLE
Fix zoom (center in canvas and use viewBox) and zoom in by default to fill the canvas

### DIFF
--- a/lib/svg-preview-view.js
+++ b/lib/svg-preview-view.js
@@ -176,8 +176,16 @@ class SvgPreviewView extends View {
       const width = svg.width() * zoomValue
       const height = svg.height() * zoomValue
 
+      svg[0].setAttribute('viewBox', '0 0 ' + svg.width() + ' ' + svg.height())
       svg.width(width).height(height)
     }
+  }
+
+  zoomFill() {
+    this.zoomReset()
+    const svg = this.canvas.find('svg')
+    svg.width('100%')
+    svg.height('100%')
   }
 
   config(key) {
@@ -256,6 +264,7 @@ class SvgPreviewView extends View {
   renderSvgText(text) {
     if (!text) { return }
     this.canvas.html(text)
+    this.zoomFill()
     this.emitter.emit('did-change-svg')
     this.originalTrigger('svg-preview:svg-changed')
   }

--- a/styles/svg-preview.less
+++ b/styles/svg-preview.less
@@ -62,6 +62,10 @@
     height: calc(~"100% - 44px");
 
     padding: @spacing;
+    
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   // Background color


### PR DESCRIPTION
This is just my hacks in my local copy. Copy anything you like into another commit.
- It doesn't actually "zoom in" (zoomValue is still 1) since we use `style="width: 100%`. The zoom label will show 100% still.
- I'm highjacking the `renderSvgText` to hook "svg loaded".
