### PR TITLE
[svg-to-raster] replaces new Buffer(...) by Buffer.from(...)

### DIFF
--- a/lib/svg-to-raster.js
+++ b/lib/svg-to-raster.js
@@ -20,6 +20,6 @@ exports.transform = (svg, outputType, callback) => {
         dataURL = canvas.toDataURL(`image/${outputType}`, 0.8)
 
         // extract the base64 encoded image, decode and return it
-        return callback(new Buffer(dataURL.replace(`data:image/${outputType};base64,`, ''), 'base64'))
+        return callback(Buffer.from(dataURL.replace(`data:image/${outputType};base64,`, ''), 'base64'))
     })
 }


### PR DESCRIPTION
- `new Buffer()` has the 'deprecated' status in node 6 and 7 
- atom is currently using node 6 

This PR replaces the `new Buffer()` call by `Buffer.from()` - which is the alternative suggested in the node 6 and 7 documentation.