### PR TITLE
symmetric zoom in and zoom out

### DIFF
--- a/lib/svg-preview-view.js
+++ b/lib/svg-preview-view.js
@@ -81,9 +81,9 @@ class SvgPreviewView extends View {
     this.controls.find('a').on('click', (e) => {
       this.changeBackground($(e.target).attr('value'))
     })
-    this.zoomOutButton.on('click', (e) => this.zoom(-0.1))
+    this.zoomOutButton.on('click', (e) => this.zoom(9 / 10 - 1))
     this.resetZoomButton.on('click', (e) => this.zoomReset())
-    this.zoomInButton.on('click', (e) => this.zoom(0.1))
+    this.zoomInButton.on('click', (e) => this.zoom(10 / 9 - 1))
   }
 
   serialize() {


### PR DESCRIPTION
When clicking zoom-in once and then zoom-out once you are currently not back at the original scale. E.g. from 100% you get to 90% and then back to 99% whereas the user expects to be back to where he started.

This patch modifies the arguments to the zoom function to actually be symmetric.